### PR TITLE
Support unlocking deadlocks with setnx/getset

### DIFF
--- a/lib/resque-lonely_job.rb
+++ b/lib/resque-lonely_job.rb
@@ -6,7 +6,7 @@ module Resque
       LOCK_TIMEOUT = 60 * 60 * 24 * 5 # 5 days
 
       def lock_timeout
-        Time.now.utc + LOCK_TIMEOUT + 1
+        Time.now.to_i + LOCK_TIMEOUT + 1
       end
 
       # Overwrite this method to uniquely identify which mutex should be used

--- a/lib/resque-lonely_job.rb
+++ b/lib/resque-lonely_job.rb
@@ -20,7 +20,7 @@ module Resque
         key = redis_key(*args)
         timeout = lock_timeout
 
-        # Per http://redis.io/commands/getset
+        # Per http://redis.io/commands/setnx
         return true  if Resque.redis.setnx(key, timeout)
         return false if Resque.redis.get(key).to_i > now
         return true  if Resque.redis.getset(key, timeout).to_i <= now

--- a/lib/resque-lonely_job.rb
+++ b/lib/resque-lonely_job.rb
@@ -16,7 +16,15 @@ module Resque
       end
 
       def can_lock_queue?(*args)
-        Resque.redis.setnx(redis_key(*args), lock_timeout)
+        now = Time.now.to_i
+        key = redis_key(*args)
+        timeout = lock_timeout
+
+        # Per http://redis.io/commands/getset
+        return true  if Resque.redis.setnx(key, timeout)
+        return false if Resque.redis.get(key).to_i > now
+        return true  if Resque.redis.getset(key, timeout).to_i <= now
+        return false
       end
 
       def unlock_queue(*args)

--- a/resque-lonely_job.gemspec
+++ b/resque-lonely_job.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'debugger'
+  gem.add_development_dependency 'timecop'
 
   gem.description   = <<desc
 Ensures that for a given queue, only one worker is working on a job at any given time.

--- a/resque-lonely_job.gemspec
+++ b/resque-lonely_job.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Resque::Plugins::LonelyJob::VERSION
 
-  gem.add_dependency 'resque', '~> 1.20.0'
+  gem.add_dependency 'resque', '>= 1.20.0'
   gem.add_development_dependency 'mock_redis', '~> 0.4.1'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'rspec'
 require 'mock_redis'
 require 'resque'
 require 'resque-lonely_job'
+require 'timecop'
 
 RSpec.configure do |config|
   config.before(:suite) do


### PR DESCRIPTION
This patch adds unlocking behavior when a worker somehow gets dead while obtaining a lock without cleaning it up and causes deadlocks. The code uses a design pattern used in http://redis.io/commands/setnx using SETNX and GETSET, to avoid the race condition.

To make it work i changed the value of lock to be an integer (UNIX timestamp) rather than a time string as it used to be.

This addresses #1.
