### PR TITLE
Update lonely_job to use new locking pattern

### DIFF
--- a/resque-lonely_job.gemspec
+++ b/resque-lonely_job.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.version       = Resque::Plugins::LonelyJob::VERSION
 
   gem.add_dependency 'resque', '~> 1.24.0'
-  gem.add_development_dependency 'mock_redis', '~> 0.4.1'
+  gem.add_development_dependency 'mock_redis'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'debugger'

--- a/resque-lonely_job.gemspec
+++ b/resque-lonely_job.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Resque::Plugins::LonelyJob::VERSION
 
-  gem.add_dependency 'resque', '>= 1.20.0'
+  gem.add_dependency 'resque', '~> 1.24.0'
   gem.add_development_dependency 'mock_redis', '~> 0.4.1'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
This takes uses the new suggestion as specified at http://redis.io/commands/set
