### PR TITLE
Sleep for 1 second before requeuing to give CPU's a rest

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,32 @@ It now doesn't matter whether job 1 and job 2 are re-ordered as whichever goes
 first will perform an atomic pop on the redis list that contains the data needed
 for its job (data x, data y, data z).
 
+#### Example #4 -- Requeue interval
+
+The behavior when multiple jobs exist in a queue protected by resque-lonely_job
+is for one job to be worked, while the other is continuously dequeued and
+requeued until the first job is finished.  This can result in that worker
+process pegging a CPU/core on a worker server.  To guard against this, the
+default behavior is to sleep for 1 second before the requeue, which will allow
+the cpu to perform other work.
+
+This can be customized using a ```@requeue_interval``` class instance variable
+in your job like so:
+
+
+    require 'resque-lonely_job'
+
+    class StrictlySerialJob
+      extend Resque::Plugins::LonelyJob
+
+      @queue = :serial_work
+      @requeue_interval = 5         # sleep for 5 seconds before requeueing
+
+      def self.perform
+        # some implementation
+      end
+    end
+
 ## Contributing
 
 1. Fork it

--- a/lib/resque-lonely_job.rb
+++ b/lib/resque-lonely_job.rb
@@ -9,6 +9,10 @@ module Resque
         Time.now.to_i + LOCK_TIMEOUT + 1
       end
 
+      def requeue_interval
+        self.instance_variable_get(:@requeue_interval) || 1
+      end
+
       # Overwrite this method to uniquely identify which mutex should be used
       # for a resque worker.
       def redis_key(*args)
@@ -37,6 +41,9 @@ module Resque
 
       def before_perform(*args)
         unless can_lock_queue?(*args)
+          # Sleep so the CPU's rest
+          sleep(requeue_interval)
+
           # can't get the lock, so re-enqueue the task
           reenqueue(*args)
 

--- a/spec/lib/lonely_job_spec.rb
+++ b/spec/lib/lonely_job_spec.rb
@@ -23,6 +23,17 @@ describe Resque::Plugins::LonelyJob do
     Resque.redis.flushall
   end
 
+  describe ".requeue_interval" do
+    it "should default to 5" do
+      expect(SerialJob.requeue_interval).to eql(1)
+    end
+
+    it "should be overridable with a class instance var" do
+      SerialJob.instance_variable_set(:@requeue_interval, 5)
+      expect(SerialJob.requeue_interval).to eql(5)
+    end
+  end
+
   describe ".can_lock_queue?" do
     it 'can lock a queue' do
       expect(SerialJob.can_lock_queue?(:serial_work)).to eql(true)
@@ -66,6 +77,10 @@ describe Resque::Plugins::LonelyJob do
   end
 
   describe ".perform" do
+    before do
+      SerialJob.instance_variable_set(:@requeue_interval, 0)
+    end
+
     describe "using the default redis key" do
       it 'should lock and unlock the queue' do
         job = Resque::Job.new(:serial_work, { 'class' => 'SerialJob', 'args' => %w[account_one job_one] })


### PR DESCRIPTION
Without this, when a worker requeues a job, it immediately starts
looking for another job without pause.  It typically finds the
just requeued job and pops it off to create a loop that pegs a
CPU core until it can actually run the job and finish.

This fixes the issue by:
- Introducing a @requeue_interval variable in jobs that can be
  used to control how long a worker will sleep before requeuing
  a job.
- Providing a default of 1 second to ensure a worker process
  won't hog a server's core.

This is a fix for issue 8:

https://github.com/wallace/resque-lonely_job/issues/8
